### PR TITLE
Changed option 'overlay' to true.

### DIFF
--- a/paper-fab-menu.html
+++ b/paper-fab-menu.html
@@ -132,9 +132,9 @@
       * Set if the overlay of screen should be used when the menu is opened.
       * @attribute overlay
       * @type boolean
-      * @default false
+      * @default true
       */
-      overlay: false,
+      overlay: true,
 
       ready: function() {
         this.calculateTransitionEffects.apply(this);


### PR DESCRIPTION
- By default,  showing overlay is more natural to support dismissing fab-menu by tapping anywhere.
